### PR TITLE
Map spawn interactions: click to select, right-click filter, timer dots (closes #62, #69, #70)

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -47,6 +47,7 @@ pub struct MapOverlaySettings {
     pub show_layer2: bool,
     pub show_layer3: bool,
     pub show_grid: bool,
+    pub show_timer_dots: bool,
     pub follow_mode: FollowMode,
 }
 
@@ -65,6 +66,7 @@ impl Default for MapOverlaySettings {
             show_layer2: true,
             show_layer3: true,
             show_grid: false,
+            show_timer_dots: true,
             follow_mode: FollowMode::None,
         }
     }
@@ -279,6 +281,15 @@ impl ClientConfig {
             "ShowGrid={}",
             if self.map_overlay.show_grid { 1 } else { 0 }
         )?;
+        writeln!(
+            f,
+            "ShowTimerDots={}",
+            if self.map_overlay.show_timer_dots {
+                1
+            } else {
+                0
+            }
+        )?;
         writeln!(f, "FollowMode={}", self.map_overlay.follow_mode.as_str())?;
         Ok(())
     }
@@ -421,6 +432,9 @@ impl ClientConfig {
             }
             if let Some(v) = overlay.get("showgrid") {
                 cfg.map_overlay.show_grid = v == "1";
+            }
+            if let Some(v) = overlay.get("showtimerdots") {
+                cfg.map_overlay.show_timer_dots = v != "0";
             }
             if let Some(v) = overlay.get("followmode") {
                 cfg.map_overlay.follow_mode = FollowMode::from_str(v);

--- a/client/src/data/mod.rs
+++ b/client/src/data/mod.rs
@@ -51,8 +51,10 @@ pub struct AppData {
     pub ground_list_column_widths: Vec<f32>,
     /// Spawn IDs currently highlighted by the search dialog.
     pub marked_ids: HashSet<u32>,
-    /// Single spawn selected by clicking a row in the spawn list.
+    /// Single spawn selected by clicking a row in the spawn list or a dot on the map canvas.
     pub selected_id: Option<u32>,
+    /// When true, the spawn list should scroll to reveal `selected_id` on the next frame.
+    pub scroll_to_selected: bool,
     /// Auto-learning respawn timer engine.
     pub observer: SpawnObserver,
     /// NPC spawn IDs seen in the current tick (scratch space for observer diff).
@@ -122,6 +124,7 @@ impl Default for AppData {
             ],
             marked_ids: HashSet::new(),
             selected_id: None,
+            scroll_to_selected: false,
             observer: SpawnObserver::default(),
             curr_tick_npc_ids: HashSet::new(),
             curr_tick_all_ids: HashSet::new(),

--- a/client/src/map_canvas.rs
+++ b/client/src/map_canvas.rs
@@ -5,20 +5,29 @@ use egui::{Color32, FontId, Painter, Pos2, Rect, Sense, Stroke, Ui, Vec2};
 use crate::config::{FollowMode, MapOverlaySettings};
 use crate::data::AppData;
 use crate::data::spawns::{ConColor, SpawnCategory, SpawnInfo, con_color};
+use crate::filters::FilterCategory;
 use crate::game_data::GameData;
 use crate::map_reader::MapData;
 
 const SPAWN_RADIUS: f32 = 4.0;
+const HOVER_RADIUS: f32 = 8.0;
 const SELF_RADIUS: f32 = 6.0;
 const GROUND_RADIUS: f32 = 4.0;
 pub(crate) const ZOOM_STEP: f32 = 1.12;
 pub(crate) const ZOOM_MIN: f32 = 0.04;
 pub(crate) const ZOOM_MAX: f32 = 20.0;
 
-/// Action produced by the map canvas context menu, to be handled by the caller.
+/// Action produced by the map canvas, to be handled by the caller.
 pub enum MapAction {
     /// User chose "Add Map Note here" — EQ-space coordinates of the right-click point.
     AddNoteAt { eq_x: f32, eq_y: f32 },
+    /// User left-clicked on or near a spawn dot. `None` means empty space (clear selection).
+    SelectSpawn { id: Option<u32> },
+    /// User chose a filter action from the map canvas right-click context menu.
+    AddToFilter {
+        name: String,
+        category: FilterCategory,
+    },
 }
 
 /// Persistent camera state for the map canvas.
@@ -93,6 +102,8 @@ impl<'a> MapCon<'a> {
             state.pan.y = (wy - focus.1) * state.zoom;
         }
 
+        let mut action: Option<MapAction> = None;
+
         // Shift+left-click → set bearing target; plain click or ESC → clear it.
         let (shift_held, esc_pressed) =
             ui.input(|i| (i.modifiers.shift, i.key_pressed(egui::Key::Escape)));
@@ -109,6 +120,34 @@ impl<'a> MapCon<'a> {
                 }
             } else {
                 state.bearing_target = None;
+                // Hit-test spawns — find the nearest dot within click radius.
+                let hit_id = response.interact_pointer_pos().map(|screen_pos| {
+                    let focus = focus_world(data);
+                    let pan = state.pan;
+                    let zoom = state.zoom;
+                    let center = response.rect.center();
+                    let to_screen = |wx: f32, wy: f32| {
+                        Pos2::new(
+                            center.x + (wx - focus.0) * zoom + pan.x,
+                            center.y - (wy - focus.1) * zoom + pan.y,
+                        )
+                    };
+                    let mut best_dist = HOVER_RADIUS;
+                    let mut best_id: Option<u32> = None;
+                    for spawn in data.spawns.iter() {
+                        let (mx, my) = eq_to_map(spawn.x, spawn.y);
+                        let sp = to_screen(mx, my);
+                        let d = screen_pos.distance(sp);
+                        if d < best_dist {
+                            best_dist = d;
+                            best_id = Some(spawn.id);
+                        }
+                    }
+                    best_id // None = empty space, Some(id) = hit spawn
+                });
+                if let Some(id) = hit_id {
+                    action = Some(MapAction::SelectSpawn { id });
+                }
             }
         }
 
@@ -158,6 +197,9 @@ impl<'a> MapCon<'a> {
         draw_mob_trails(&ctx, data, filtered_ids);
         draw_ground_items(&ctx, data, z_filter);
         draw_spawns(&ctx, data, z_filter, overlay, filtered_ids);
+        if overlay.show_timer_dots {
+            draw_timer_dots(&ctx, data);
+        }
         draw_self(&ctx, data);
         draw_annotations(&ctx, data);
         if let Some(target) = state.bearing_target {
@@ -167,12 +209,68 @@ impl<'a> MapCon<'a> {
         draw_follow_indicator(&ctx, overlay);
 
         if let Some(hover_pos) = response.hover_pos() {
-            draw_hover_tooltip(ui, &ctx, data, hover_pos, z_filter);
+            draw_hover_tooltip(ui, &ctx, data, hover_pos, z_filter, overlay);
         }
 
         // Context menu (shown on right-click, persists until dismissed).
-        let mut action: Option<MapAction> = None;
         response.context_menu(|ui| {
+            // Hit-test: find the nearest spawn within HOVER_RADIUS screen pixels of the
+            // right-click point, using map-space distance to avoid needing a DrawCtx here.
+            let nearby: Option<String> = state.context_menu_pos.and_then(|(wx, wy)| {
+                let threshold = HOVER_RADIUS / state.zoom.max(0.001);
+                let mut best_dist = threshold;
+                let mut best_name: Option<String> = None;
+                for spawn in data.spawns.iter() {
+                    let (mx, my) = eq_to_map(spawn.x, spawn.y);
+                    let d = ((mx - wx) * (mx - wx) + (my - wy) * (my - wy)).sqrt();
+                    if d < best_dist {
+                        best_dist = d;
+                        best_name = Some(
+                            spawn
+                                .name
+                                .trim_end_matches(|c: char| c.is_ascii_digit())
+                                .trim_end()
+                                .to_string(),
+                        );
+                    }
+                }
+                best_name
+            });
+
+            if let Some(ref name) = nearby {
+                ui.label(egui::RichText::new(name).strong());
+                ui.separator();
+                if ui.button("Add to Hunt").clicked() {
+                    action = Some(MapAction::AddToFilter {
+                        name: name.clone(),
+                        category: FilterCategory::Hunt,
+                    });
+                    ui.close();
+                }
+                if ui.button("Add to Caution").clicked() {
+                    action = Some(MapAction::AddToFilter {
+                        name: name.clone(),
+                        category: FilterCategory::Caution,
+                    });
+                    ui.close();
+                }
+                if ui.button("Add to Danger").clicked() {
+                    action = Some(MapAction::AddToFilter {
+                        name: name.clone(),
+                        category: FilterCategory::Danger,
+                    });
+                    ui.close();
+                }
+                if ui.button("Add to Rare").clicked() {
+                    action = Some(MapAction::AddToFilter {
+                        name: name.clone(),
+                        category: FilterCategory::Rare,
+                    });
+                    ui.close();
+                }
+                ui.separator();
+            }
+
             if let Some((wx, wy)) = state.context_menu_pos {
                 if ui.button("Add Map Note here…").clicked() {
                     action = Some(MapAction::AddNoteAt {
@@ -326,6 +424,28 @@ fn draw_grid(ctx: &DrawCtx) {
             );
         }
         gy += interval;
+    }
+}
+
+fn draw_timer_dots(ctx: &DrawCtx, data: &AppData) {
+    for timer in data.timers.iter() {
+        let (mx, my) = eq_to_map(timer.x, timer.y);
+        let pos = ctx.to_screen(mx, my);
+        if !ctx.is_visible(pos) {
+            continue;
+        }
+        let secs = timer.secs_remaining();
+        let color = if secs <= 0 {
+            Color32::WHITE
+        } else if secs <= 30 {
+            Color32::from_rgb(255, 60, 60)
+        } else if secs <= 120 {
+            Color32::from_rgb(255, 210, 0)
+        } else {
+            Color32::from_rgb(0, 220, 220)
+        };
+        ctx.painter
+            .circle_stroke(pos, SPAWN_RADIUS + 4.0, Stroke::new(2.0, color));
     }
 }
 
@@ -663,6 +783,7 @@ fn draw_follow_indicator(ctx: &DrawCtx, overlay: &MapOverlaySettings) {
 enum HoverHit<'a> {
     Spawn(&'a SpawnInfo),
     Ground(&'a crate::data::ground::GroundItem),
+    Timer(&'a crate::data::timers::SpawnTimer),
 }
 
 fn draw_hover_tooltip(
@@ -671,8 +792,8 @@ fn draw_hover_tooltip(
     data: &AppData,
     hover_pos: Pos2,
     z_filter: Option<(f32, f32)>,
+    overlay: &MapOverlaySettings,
 ) {
-    const HOVER_RADIUS: f32 = 8.0;
     let mut best_dist = f32::MAX;
     let mut hit: Option<HoverHit<'_>> = None;
 
@@ -705,6 +826,21 @@ fn draw_hover_tooltip(
         if dist <= HOVER_RADIUS && dist < best_dist {
             best_dist = dist;
             hit = Some(HoverHit::Ground(item));
+        }
+    }
+
+    if overlay.show_timer_dots {
+        for timer in data.timers.iter() {
+            let (mx, my) = eq_to_map(timer.x, timer.y);
+            let screen_pos = ctx.to_screen(mx, my);
+            if !ctx.is_visible(screen_pos) {
+                continue;
+            }
+            let dist = hover_pos.distance(screen_pos);
+            if dist <= HOVER_RADIUS && dist < best_dist {
+                best_dist = dist;
+                hit = Some(HoverHit::Timer(timer));
+            }
         }
     }
 
@@ -745,6 +881,14 @@ fn draw_hover_tooltip(
                 HoverHit::Ground(g) => {
                     ui.label(&g.name);
                     ui.label(format!("Dist: {}", player_dist(g.x, g.y)));
+                }
+                HoverHit::Timer(t) => {
+                    ui.label(egui::RichText::new(&t.name).strong());
+                    if t.is_spawned() {
+                        ui.label("Ready — check spawn point");
+                    } else {
+                        ui.label(format!("Respawn in: {}", t.countdown_str()));
+                    }
                 }
             }
         },

--- a/client/src/ui/main_window.rs
+++ b/client/src/ui/main_window.rs
@@ -866,6 +866,15 @@ impl eframe::App for MainApp {
                     ui.close();
                 }
                 ui.separator();
+                if ui
+                    .checkbox(
+                        &mut self.config.map_overlay.show_timer_dots,
+                        "Show Timer Dots",
+                    )
+                    .clicked()
+                {
+                    self.save_config();
+                }
                 let mut trails_on = self.data.lock().unwrap().trails_enabled;
                 if ui.checkbox(&mut trails_on, "Mob Trails  T").clicked() {
                     let mut data = self.data.lock().unwrap();
@@ -1107,6 +1116,27 @@ impl eframe::App for MainApp {
                     self.add_note.open = true;
                     self.add_note.text.clear();
                     self.add_note.override_pos = Some((eq_x, eq_y, eq_z));
+                }
+                MapAction::AddToFilter { name, category } => {
+                    self.handle_spawn_action(crate::ui::spawn_list::SpawnAction::AddToFilter {
+                        name,
+                        category,
+                    });
+                }
+                MapAction::SelectSpawn { id } => {
+                    let mut data = self.data.lock().unwrap();
+                    match id {
+                        Some(spawn_id) if data.selected_id == Some(spawn_id) => {
+                            data.selected_id = None; // toggle off
+                        }
+                        Some(spawn_id) => {
+                            data.selected_id = Some(spawn_id);
+                            data.scroll_to_selected = true;
+                        }
+                        None => {
+                            data.selected_id = None;
+                        }
+                    }
                 }
             }
         }

--- a/client/src/ui/spawn_list.rs
+++ b/client/src/ui/spawn_list.rs
@@ -58,6 +58,12 @@ pub fn show(
     let player_pos = data.player_pos();
     let current_selected = data.selected_id; // Copy before spawns borrows data
     let current_target = data.target_id;
+    // Copy before spawns borrows data; used inside the scroll closure without touching data.
+    let scroll_to_id: Option<u32> = if data.scroll_to_selected {
+        data.selected_id
+    } else {
+        None
+    };
 
     let mut spawns: Vec<_> = data.spawns.iter().collect();
 
@@ -298,6 +304,11 @@ pub fn show(
                 let (sx, sy, sz) = (s.x, s.y, s.z);
                 let spawn_id = s.id;
 
+                // Scroll to this row when selection was set from the map canvas.
+                if scroll_to_id == Some(s.id) {
+                    ui.scroll_to_rect(row_rect, Some(egui::Align::Center));
+                }
+
                 // ui.interact() gives the rect a click sense so context_menu fires on right-click
                 let row_resp = ui.interact(row_rect, ui.id().with(s.id), egui::Sense::click());
 
@@ -367,6 +378,9 @@ pub fn show(
         });
 
     drop(spawns);
+    if scroll_to_id.is_some() {
+        data.scroll_to_selected = false;
+    }
     if let Some(id) = pending_select {
         if data.selected_id == Some(id) {
             data.selected_id = None; // click same row again to deselect


### PR DESCRIPTION
## Summary

Three map canvas interaction features implemented together, sharing the same hit-test infrastructure.

- **#70 — Left-click spawn to select:** clicking a spawn dot selects it (gold ring + spawn list scrolls to row); clicking the same dot deselects; clicking empty space clears selection; drag does not trigger selection
- **#69 — Right-click spawn for filter actions:** right-clicking near a spawn shows the mob name as a header then Hunt / Caution / Danger / Rare filter buttons, each routing through the existing scope picker dialog (Global or Zone); right-clicking empty space shows the existing map menu unchanged; hit-test uses map-space distance so accuracy is correct at any zoom level
- **#62 — Timer dots on map canvas:** colored ring drawn at each active timer location — cyan (> 2 min), yellow (≤ 2 min), red (≤ 30 s), white (overdue/ready); hovering within 8px shows a tooltip with the timer name and countdown string; **Show Timer Dots** checkbox in Map menu, persisted as `ShowTimerDots=` in `[MapOverlay]`, default on

### Also includes
- `HOVER_RADIUS` const promoted from local to module level so hit-test and tooltip share the same value
- `MapAction` enum extended with `SelectSpawn { id: Option<u32> }` and `AddToFilter { name, category }` variants
- `AppData.scroll_to_selected: bool` flag for scroll-to-row after map-click selection

## Test plan

- [ ] Left-click a spawn dot — gold ring appears, spawn list scrolls to that row
- [ ] Left-click same dot again — deselects
- [ ] Left-click empty map area — clears selection
- [ ] Drag map — no spurious selection
- [ ] Right-click a spawn dot — header shows mob name, filter buttons appear
- [ ] Click "Add to Hunt" — scope picker opens, filter is saved and applied
- [ ] Right-click empty map area — only Add Map Note / Center map here shown
- [ ] Timer dots visible on map with correct colors for each time bucket
- [ ] Hover over timer dot — tooltip shows name and countdown
- [ ] Show Timer Dots toggle in Map menu — hides/shows dots and tooltip
- [ ] Setting persists after restart
- [ ] 145/145 tests pass, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)