### PR TITLE
Sticky timers — survive zone changes for tracked named mobs (#72)

### DIFF
--- a/client/src/data/timers.rs
+++ b/client/src/data/timers.rs
@@ -70,6 +70,8 @@ pub struct SpawnTimer {
     pub spawn_time: Option<DateTime<Utc>>,
     /// Zone name where this timer was learned.
     pub zone: String,
+    /// Sticky timers survive zone changes and are not cleared until "Clear All" is used.
+    pub sticky: bool,
 }
 
 impl SpawnTimer {
@@ -87,6 +89,7 @@ impl SpawnTimer {
             spawn_count: 0,
             spawn_time: None,
             zone: String::new(),
+            sticky: false,
         }
     }
 
@@ -166,6 +169,11 @@ impl TimerStore {
         self.timers.clear();
     }
 
+    /// Remove all non-sticky timers (called on zone change).
+    pub fn clear_non_sticky(&mut self) {
+        self.timers.retain(|t| t.sticky);
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &SpawnTimer> {
         self.timers.iter()
     }
@@ -232,7 +240,7 @@ impl TimerStore {
             let all_names = t.all_names.join(",");
             writeln!(
                 f,
-                "{};{};{};{};{};{};{};{};{};{};{}",
+                "{};{};{};{};{};{};{};{};{};{};{};{}",
                 t.spawn_loc,
                 t.spawn_count,
                 t.respawn_secs,
@@ -244,6 +252,7 @@ impl TimerStore {
                 t.x,
                 t.y,
                 t.z,
+                t.sticky as u8,
             )?;
         }
         Ok(())
@@ -261,7 +270,7 @@ fn timer_path(zone: &str, dir: &str) -> std::path::PathBuf {
 /// - field[0] has comma AND field[3] is not an i64  → C# MySEQ format (migrate)
 /// - field[0] has no comma                          → old Rust format (migrate)
 fn parse_line(line: &str, zone: &str) -> Option<(SpawnTimer, bool)> {
-    let parts: Vec<&str> = line.splitn(12, ';').collect();
+    let parts: Vec<&str> = line.splitn(13, ';').collect();
     if parts.is_empty() {
         return None;
     }
@@ -298,6 +307,11 @@ fn parse_new_format(parts: &[&str], zone: &str) -> Option<SpawnTimer> {
     let x: f32 = parts[8].parse().ok()?;
     let y: f32 = parts[9].parse().ok()?;
     let z: f32 = parts[10].parse().ok()?;
+    let sticky = parts
+        .get(11)
+        .and_then(|s| s.trim().parse::<u8>().ok())
+        .map(|v| v != 0)
+        .unwrap_or(false);
 
     let killed_at = (kill_time_unix > 0)
         .then(|| DateTime::from_timestamp(kill_time_unix, 0))
@@ -320,6 +334,7 @@ fn parse_new_format(parts: &[&str], zone: &str) -> Option<SpawnTimer> {
         spawn_count,
         spawn_time,
         zone: zone.to_owned(),
+        sticky,
     })
 }
 
@@ -357,6 +372,7 @@ fn parse_cs_format(parts: &[&str], zone: &str) -> Option<SpawnTimer> {
         spawn_count,
         spawn_time,
         zone: zone.to_owned(),
+        sticky: false,
     })
 }
 
@@ -401,6 +417,7 @@ fn parse_old_format(parts: &[&str], zone: &str) -> Option<SpawnTimer> {
         spawn_count,
         spawn_time,
         zone: zone.to_owned(),
+        sticky: false,
     })
 }
 
@@ -559,6 +576,12 @@ impl SpawnObserver {
                             // Prefer a named/boss mob (starts uppercase or '#') as display name
                             let display_name = best_display_name(&all_names, &kill.name).to_owned();
 
+                            let existing_sticky = timers
+                                .timers
+                                .iter()
+                                .find(|t| t.spawn_loc == key)
+                                .map(|t| t.sticky)
+                                .unwrap_or(false);
                             timers.add(SpawnTimer {
                                 name: display_name,
                                 spawn_loc: key,
@@ -572,6 +595,7 @@ impl SpawnObserver {
                                 spawn_count: obs.spawn_count,
                                 spawn_time: Some(now),
                                 zone: zone.to_owned(),
+                                sticky: existing_sticky,
                             });
                             log.push(format!(
                                 "[Timer] Auto-timer promoted: {} — avg {}s over {} cycles",

--- a/client/src/data/timers.rs
+++ b/client/src/data/timers.rs
@@ -169,11 +169,6 @@ impl TimerStore {
         self.timers.clear();
     }
 
-    /// Remove all non-sticky timers (called on zone change).
-    pub fn clear_non_sticky(&mut self) {
-        self.timers.retain(|t| t.sticky);
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = &SpawnTimer> {
         self.timers.iter()
     }

--- a/client/src/data/timers.rs
+++ b/client/src/data/timers.rs
@@ -108,10 +108,18 @@ impl SpawnTimer {
         self.secs_remaining() <= 0
     }
 
+    /// True when the mob is known to be alive (spawned but not yet killed).
+    pub fn is_alive(&self) -> bool {
+        self.killed_at.is_none()
+    }
+
     pub fn countdown_str(&self) -> String {
+        if self.killed_at.is_none() {
+            return "ALIVE".to_owned();
+        }
         let secs = self.secs_remaining();
         if secs <= 0 {
-            return "SPAWNED".to_owned();
+            return "UNKNOWN".to_owned();
         }
         let h = secs / 3600;
         let m = (secs % 3600) / 60;
@@ -558,7 +566,7 @@ impl SpawnObserver {
                                 x: kill.x,
                                 y: kill.y,
                                 z: kill.z,
-                                killed_at: Some(now),
+                                killed_at: None, // mob just spawned; countdown starts on kill
                                 respawn_secs: avg,
                                 is_auto: true,
                                 spawn_count: obs.spawn_count,
@@ -1339,14 +1347,14 @@ mod tests {
     fn countdown_str_shows_spawned_when_expired() {
         let mut t = SpawnTimer::new("Boss", 0.0, 0.0, 0.0, 0);
         t.killed_at = Some(Utc::now() - Duration::seconds(60));
-        assert_eq!(t.countdown_str(), "SPAWNED");
+        assert_eq!(t.countdown_str(), "UNKNOWN");
     }
 
     #[test]
-    fn countdown_str_shows_spawned_when_no_kill_time() {
+    fn countdown_str_shows_alive_when_no_kill_time() {
         let mut t = SpawnTimer::new("Boss", 0.0, 0.0, 0.0, 1800);
         t.killed_at = None;
-        assert_eq!(t.countdown_str(), "SPAWNED");
+        assert_eq!(t.countdown_str(), "ALIVE");
     }
 
     #[test]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -61,7 +61,12 @@ fn main() -> eframe::Result {
     )
 }
 
-fn relaunch_if_known_name(_known_stem: &str) {
+fn relaunch_if_known_name(known_stem: &str) {
+    // Debug builds don't need the self-copy trick; skip it so the icon shows correctly in IDEs.
+    if cfg!(debug_assertions) {
+        return;
+    }
+
     let exe = match std::env::current_exe() {
         Ok(p) => p,
         Err(_) => return,
@@ -69,6 +74,12 @@ fn relaunch_if_known_name(_known_stem: &str) {
 
     // Already running as a .bin copy — proceed normally.
     if exe.extension().and_then(|e| e.to_str()) == Some("bin") {
+        return;
+    }
+
+    // Not the installed binary name — skip the relaunch.
+    let stem = exe.file_stem().and_then(|s| s.to_str()).unwrap_or_default();
+    if !stem.eq_ignore_ascii_case(known_stem) {
         return;
     }
 

--- a/client/src/map_canvas.rs
+++ b/client/src/map_canvas.rs
@@ -962,8 +962,10 @@ fn draw_hover_tooltip(
                 }
                 HoverHit::Timer(t) => {
                     ui.label(egui::RichText::new(&t.name).strong());
-                    if t.is_spawned() {
-                        ui.label("Ready — check spawn point");
+                    if t.is_alive() {
+                        ui.label("Alive — timer starts on kill");
+                    } else if t.is_spawned() {
+                        ui.label("Unknown — check spawn point");
                     } else {
                         ui.label(format!("Respawn in: {}", t.countdown_str()));
                     }

--- a/client/src/ui/main_window.rs
+++ b/client/src/ui/main_window.rs
@@ -260,6 +260,7 @@ impl MainApp {
     }
 
     fn handle_zone_change(&mut self, new_zone: String) {
+        let mut sticky_carry: Vec<SpawnTimer> = Vec::new();
         if !self.prev_zone.is_empty() {
             let data = self.data.lock().unwrap();
             let _ = data.timers.save(&self.prev_zone, &self.config.timer_dir);
@@ -271,8 +272,12 @@ impl MainApp {
                 &self.prev_zone,
                 &self.config.timer_dir,
             );
+            sticky_carry = data.timers.iter().filter(|t| t.sticky).cloned().collect();
         }
-        let new_timers = TimerStore::load(&new_zone, &self.config.timer_dir);
+        let mut new_timers = TimerStore::load(&new_zone, &self.config.timer_dir);
+        for t in sticky_carry {
+            new_timers.add(t);
+        }
         let new_annotations = AnnotationStore::load(&new_zone, &self.config.annotations_dir);
         let new_obs = SpawnObserver::load(&new_zone, &self.config.timer_dir);
         // Zone names from EQ are lowercase short names; map files use the same convention.
@@ -433,6 +438,12 @@ impl<'a> TabViewer for WinSeqTabViewer<'a> {
                     Some(TimerAction::CenterMap { x, y }) => {
                         let (mx, my) = crate::map_canvas::eq_to_map_pub(x, y);
                         self.map_pane.state.pending_center = Some((mx, my));
+                    }
+                    Some(TimerAction::ToggleSticky(idx)) => {
+                        if let Some(t) = data.timers.timers.get_mut(idx) {
+                            t.sticky = !t.sticky;
+                            data.timers_dirty = true;
+                        }
                     }
                     None => {}
                 }

--- a/client/src/ui/timer_list.rs
+++ b/client/src/ui/timer_list.rs
@@ -6,6 +6,7 @@ use crate::data::AppData;
 pub enum TimerAction {
     ClearAll,
     CenterMap { x: f32, y: f32 },
+    ToggleSticky(usize),
 }
 
 const HEADERS: &[&str] = &[
@@ -160,10 +161,11 @@ pub fn show(
                     ui.visuals().text_color()
                 };
 
-                let name_cell = if t.is_auto {
-                    format!("{} [A]", t.name)
-                } else {
-                    t.name.clone()
+                let name_cell = match (t.is_auto, t.sticky) {
+                    (true, true) => format!("{} [A][S]", t.name),
+                    (true, false) => format!("{} [A]", t.name),
+                    (false, true) => format!("{} [S]", t.name),
+                    (false, false) => t.name.clone(),
                 };
 
                 let cells: [String; 10] = [
@@ -263,6 +265,15 @@ pub fn show(
                 }
 
                 row_resp.context_menu(|ui| {
+                    let sticky_label = if t.sticky {
+                        "Remove Sticky"
+                    } else {
+                        "Make Sticky"
+                    };
+                    if ui.button(sticky_label).clicked() {
+                        timer_action = Some(TimerAction::ToggleSticky(i));
+                        ui.close();
+                    }
                     if ui.button("Remove timer").clicked() {
                         remove_idx = Some(i);
                         ui.close();

--- a/client/src/ui/timer_list.rs
+++ b/client/src/ui/timer_list.rs
@@ -150,7 +150,9 @@ pub fn show(
             for (i, t) in &timers_with_idx {
                 let i = *i;
                 let countdown = t.countdown_str();
-                let color = if t.is_spawned() {
+                let color = if t.is_alive() {
+                    egui::Color32::from_rgb(80, 200, 80)
+                } else if t.is_spawned() {
                     egui::Color32::from_rgb(255, 80, 80)
                 } else if t.secs_remaining() < 60 {
                     egui::Color32::from_rgb(255, 210, 0)


### PR DESCRIPTION
## Summary

- Adds `sticky: bool` to `SpawnTimer`, persisted as field 11 in the timer file (backward-compatible — old files load with `sticky = false`)
- On zone change, sticky timers are carried forward into the new zone's timer list instead of being cleared
- Auto-promotion preserves the existing sticky flag when replacing a promoted timer
- Timer list right-click context menu: **Make Sticky** / **Remove Sticky** toggle
- Name column shows `[S]` badge for sticky timers; combines with `[A]` for auto-learned as `[A][S]`
- Toggling sticky marks `timers_dirty` so the auto-save fires within 60 seconds

Also includes pre-branch UX fixes committed on this branch:
- Timer countdown now starts on mob kill, not on spawn (auto-timer promotion sets `killed_at = None`)
- Rename countdown state `SPAWNED` → `UNKNOWN` (window elapsed, mob presence unconfirmed)
- New `ALIVE` state (green) when mob is known to be up, waiting for kill
- Skip exe-relaunch in debug builds so window icon shows correctly in RustRover

## Test plan

- [ ] Right-click a timer row → "Make Sticky" appears; clicking it adds `[S]` to the name
- [ ] Right-click a sticky timer → "Remove Sticky" appears; clicking it removes `[S]`
- [ ] Zone change: sticky timers remain in the list; non-sticky timers are replaced by the new zone's timers
- [ ] Sticky flag survives auto-timer re-promotion (observe a 3rd respawn cycle — `[S]` stays)
- [ ] Timer file contains `1` in field 11 for sticky timers; `0` for non-sticky
- [ ] Old timer files (11 fields) load correctly with `sticky = false`
- [ ] "Clear All Timers" removes sticky and non-sticky timers alike
- [ ] ALIVE (green) shows when mob just spawned; countdown starts only after kill
- [ ] UNKNOWN (red) shows when respawn window has elapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)